### PR TITLE
feat(loss): add DefectSegmentationLoss (Dice) and pytest suite

### DIFF
--- a/dataloader.py
+++ b/dataloader.py
@@ -1,0 +1,128 @@
+import torch
+from torch.utils.data import DataLoader
+import torchvision
+from torchvision.tv_tensors import Image, Mask
+from torch.utils.data import Dataset, DataLoader
+from torchvision.transforms import v2 as transforms
+import os
+
+
+class DefectDataset(Dataset):
+    def __init__(self, img_dir: str, img_size:int = 640,  train:bool = True):
+
+        '''
+        img_dir: Directory containing images and masks (if train=True). e.g. 'data/test/white_bracket'
+        img_size: Desired size to which images and masks will be resized (img_size x img_size)
+        train: Boolean indicating whether the dataset is for training (True) and validation, False fortesting
+        '''
+
+        self.train = train
+        self.img_size = img_size
+        self.images = []
+        if self.train:
+            self.masks = []
+
+        for directory in os.listdir(img_dir):
+
+            directory_path = os.path.join(img_dir, directory) # e.g. 'test/white_bracket/hole_defect'
+
+            for image in os.listdir(directory_path):
+
+                if image.endswith('.png'):    
+                    self.images.append(os.path.join(img_dir, directory, image)) # e.g. 'test/white_bracket/hole_defect/img1.png'
+
+                    if self.train:
+                        if directory != 'good': #Since good images don't have masks
+                            self.masks.append(os.path.join(img_dir, 'ground_truth', directory, image)) # e.g. 'test/white_bracket/ground_truth/hole_defect/img1.png'
+                        else:
+                            self.masks.append('empty') #Placeholder for good images
+
+        if self.train:
+
+            assert len(self.images) == len(self.masks), "Number of images and masks should be the same in training mode"
+
+            self.train_transform = transforms.Compose([transforms.ToImage(),
+                                                        transforms.toDType(torch.float32, scale = True),
+                                                        transforms.RandomHorizontalFlip(p = 0.5),
+                                                        transforms.RandomVerticalFlip(p = 0.5),
+                                                        transforms.RandomAffine(degrees=15, translate=(0.1, 0.1), scale=(0.9, 1.1)),
+                                                        transforms.ColorJitter(brightness=0.2, contrast=0.2, saturation=0.2, hue=0.1),
+                                                        transforms.Resize((self.img_size, self.img_size)),
+                                                        transforms.Normalize(mean=[0.485, 0.456, 0.406],\
+                                                                            std=[0.229, 0.224, 0.225]), # Placeholder transforms for training images
+                                        ]) 
+            
+
+        self.val_transform = transforms.Compose([
+                                                transforms.ToImage(),
+                                                transforms.DType(torch.float32, scale = True),
+                                                transforms.Resize((img_size, img_size)),
+                                                transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                                                                    std=[0.229, 0.224, 0.225]), # Placeholder transforms for validation images
+                                        ])
+
+    def __len__(self):
+        return len(self.images)
+
+    def __getitem__(self, idx):
+        # Load images
+        img_path = self.images[idx]
+        image = Image.open(img_path).convert('RGB')
+        
+        if self.train:
+            mask_path = self.masks[idx]
+            if mask_path == 'empty':
+                mask = torch.zeros((image.shape[1], image.shape[2]), dtype=torch.uint8) # Create an empty mask for good images
+            else:
+                mask = Image.open(mask_path).convert('L')
+
+            image, mask = Image(image), Mask(mask)
+            image, mask = self.train_transform(image, mask)
+
+            return image, mask
+
+        else:
+            image = Image(image)
+            image = self.val_transform(image)    
+    
+            return image
+
+# Unnormalize helper
+def _unnormalize(img: torch.Tensor, mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)):
+    # img: [3,H,W] float tensor
+    mean = torch.tensor(mean, device=img.device).view(3, 1, 1)
+    std = torch.tensor(std, device=img.device).view(3, 1, 1)
+    return (img * std + mean).clamp(0, 1)
+
+@torch.no_grad()
+def visualize_train_samples(dataset: DataLoader, n: int = 8, mean=(0.485,0.456,0.406), std=(0.229,0.224,0.225)):
+    """
+    Plots a 2×n grid (row1: images, row2: corresponding masks) using first n samples.
+    Works with your DefectDataset(train=True).
+    """
+    n = min(n, len(dataset))
+    imgs, masks = [], []
+    for i in range(n):
+        img, msk, _ = dataset[i]  # [3,H,W], [H,W]
+        imgs.append(_unnormalize(img, mean, std).cpu())
+        masks.append(msk.cpu())
+
+    H = 2
+    W = n
+    fig, axes = plt.subplots(H, W, figsize=(2.3*W, 2.3*H))
+
+    for j in range(W):
+        # row 0: image
+        ax0 = axes[0, j] if W > 1 else axes[0]
+        ax0.imshow(imgs[j].permute(1, 2, 0).numpy())
+        ax0.set_title(f"img {j}")
+        ax0.axis("off")
+
+        # row 1: mask
+        ax1 = axes[1, j] if W > 1 else axes[1]
+        ax1.imshow(masks[j].numpy(), cmap="gray", vmin=0, vmax=masks[j].max().item() or 1)
+        ax1.set_title(f"mask {j}")
+        ax1.axis("off")
+
+    plt.tight_layout()
+    plt.show()

--- a/loss.py
+++ b/loss.py
@@ -1,0 +1,50 @@
+import torch
+import torch.nn as nn
+import pytest
+
+_ALLOWED = {'DiceLoss'}
+
+class DefectSegmentationLoss(nn.Module):
+    def __init__(self, loss_type = 'DiceLoss'):
+        super().__init__()
+
+        if loss_type not in _ALLOWED:
+            raise ValueError(f"loss_type must be one of {_ALLOWED}, got {loss_type!r}")
+
+        self.criterion = loss_type
+    
+    def dice_loss(self, pred:torch.Tensor, target:torch.tensor, smooth:float = 1e-4)->torch.Tensor:
+        """
+        Computes the Dice Loss for binary segmentation.
+        Args:
+            pred: Tensor of predictions (batch_size, 1, H, W).
+            target: Tensor of ground truth (batch_size, 1, H, W).
+            smooth: Smoothing factor to avoid division by zero.
+        Returns:
+            Scalar Dice Loss.
+        """
+        # Apply sigmoid to convert logits to probabilities
+        pred = torch.sigmoid(pred)
+        
+        # Calculate intersection and union
+        intersection = (pred * target).sum(dim = (2, 3))
+        union = pred.sum(dim = (2, 3)) + target.sum(dim = (2, 3))
+        
+        # Compute Dice Coefficient
+        dice = (2. * intersection + smooth) / (union + smooth)
+        
+        # Return Dice Loss
+        return 1 - dice.mean()
+
+    def forward(self, outputs: torch.Tensor, targets:torch.Tensor) -> torch.Tensor:
+        
+        '''
+        Computes the loss between model outputs and ground truth targets.
+        Args:
+            outputs: Model predictions (logits) of shape (batch_size, 1, H, W).
+            targets: Ground truth masks of shape (batch_size, 1, H, W).
+        Returns:
+            Computed loss value.
+        '''
+        if self.criterion == 'DiceLoss':
+            return self.dice_loss(outputs, targets)

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,0 +1,40 @@
+import torch
+from loss import DefectSegmentationLoss
+import pytest
+
+def make_binary_batch(B = 2, H = 32, W = 32):
+    """
+    Half-left foreground mask, logits_good aligns with targets, logits_bad inverts them minus a scalar.
+    """
+    targets = torch.zeros(B, 1, H, W)
+    targets[:, :, : W // 2] = 1.0
+
+    logits_good = torch.full((B, 1, H, W), -20.0)
+    logits_good[:, :, :, : W // 2] = 20.0
+
+    logits_bad = -logits_good - 5.0
+    return logits_good, logits_bad, targets
+
+@pytest.mark.parametrize("loss_type", ["DiceLoss"])
+def test_binary_perfect_vs_wrong(loss_type):
+    logits_good, logits_bad, targets = make_binary_batch(B = 1, H = 64, W = 64)
+
+    crit = DefectSegmentationLoss(loss_type = loss_type)
+    good = crit(logits_good, targets)
+    bad = crit(logits_bad, targets)
+
+    assert good < bad, f"{loss_type}: loss for good preds must be lower than for bad preds"
+
+@pytest.mark.parametrize("loss_type", ["DiceLoss"])
+def test_binary_scalar_and_backward(loss_type):
+    B, H, W = 2, 32, 32
+    logits = torch.randn(B, 1, H, W, requires_grad = True)
+    targets = torch.randint(0, 2, (B, 1, H, W))
+
+    crit = DefectSegmentationLoss(loss_type = loss_type)
+    loss = crit(logits, targets)
+
+    assert loss.ndim == 0, f"{loss_type} should return a scalar"
+    assert torch.isfinite(loss), f"{loss_type} produced non-finite loss"
+    loss.backward()
+    assert logits.grad is not None


### PR DESCRIPTION
**Summary**
Introduce a dedicated loss module for segmentation with a binary Dice loss implementation and accompanying tests.

**Changes**

1. loss.py: DefectSegmentationLoss class

- Expects logits; applies sigmoid internally.
- Uses small smooth (ε) to avoid div-by-zero
- Raises ValueError for unsupported loss_type.

2. tests/test_loss.py: pytest covering

- scalar output + backward,
- perfect vs. wrong predictions ordering